### PR TITLE
API runs on HTTPS by default and add file README.md with solution for…

### DIFF
--- a/src/api/README.md
+++ b/src/api/README.md
@@ -1,0 +1,63 @@
+# The Full Stack Team
+
+# Issue: Changes in the `.env` File Not Reflected in the Application
+
+### Problem Description
+When changes are made to the `.env` file (e.g., user passwords for RabbitMQ or SQL Server) and containers are deleted to regenerate them, the updates are not reflected. This happens because the old data persists in the volumes configured in Docker, preventing changes to passwords and configurations in the `.env` file from being applied to the new containers.
+
+---
+
+## Solution: Steps to Properly Update the Data
+
+### **Step 1: Remove Containers**
+Delete the containers using Docker Desktop or run the following command to stop and remove the current containers:
+```bash
+docker-compose down
+```
+
+### **Step 2: Delete Persistent Volumes**
+1. **Using Docker Desktop**:
+   - Open Docker Desktop.
+   - Navigate to the "Volumes" section.
+   - Identify and delete the volumes related to the project.
+
+2. **Using the terminal**:
+   List all volumes:
+   ```bash
+   docker volume ls
+   ```
+   Then, delete the volumes associated with the project:
+   ```bash
+   docker volume rm <volume-name>
+   ```
+
+### **Step 3: Remove Files Generated in the File System**
+1. Locate the folder where Docker stores persistent data. According to the `docker-compose.yml` file, each service has a volume configuration with paths similar to this:
+   ```yaml
+   volumes:
+     - ./infrastructure/docker/<service-name>-data:/data/path
+   ```
+   For example:
+   - SQL Server: `./infrastructure/docker/sqlserver-data`
+   - RabbitMQ: `./infrastructure/docker/rabbitmq-data`
+   - MongoDB: `./infrastructure/docker/mongo-data`
+
+2. Manually delete the files and directories inside the `docker` folder from your file explorer.
+
+### **Step 4: Rebuild the Containers**
+Run the project again or rebuild the containers using the following Docker Compose command. This will regenerate the containers and volumes based on the `docker-compose.yml` configurations:
+```bash
+docker-compose up --build
+```
+---
+
+## Important Notes
+- During development, you can temporarily disable volumes by removing or commenting out the `volumes` section in the `docker-compose.yml` file. For example:
+   ```yaml
+   volumes:
+     - ./infrastructure/docker/sqlserver-data:/var/opt/mssql/data
+   ```
+
+- Remember to re-enable them before moving to production to ensure data persistence.
+
+- Docker will automatically generate new volumes and data in the folders specified in the `docker-compose.yml` file when you rebuild the containers.

--- a/src/api/docker-compose.override.yml
+++ b/src/api/docker-compose.override.yml
@@ -6,7 +6,8 @@ services:
       - ASPNETCORE_ENVIRONMENT=Development
       - ASPNETCORE_HTTP_PORT=7100
       - ASPNETCORE_HTTPS_PORT=7101
+      - ASPNETCORE_URLS=https://+:7101
 
-    volumes:        
-      - ${APPDATA}/Microsoft/UserSecrets:/home/app/.microsoft/usersecrets:ro
-      - ${APPDATA}/ASP.NET/Https:/home/app/.aspnet/https:ro
+    #volumes:        
+      #- ${APPDATA}/Microsoft/UserSecrets:/home/app/.microsoft/usersecrets:ro
+      #- ${APPDATA}/ASP.NET/Https:/home/app/.aspnet/https:ro

--- a/src/api/docker-compose.yml
+++ b/src/api/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - tfst-seq
       - tfst-mongo
     volumes:
-      - ${USERPROFILE}/.aspnet/https:/https/
+      - ${APPDATA}/ASP.NET/Https:/home/app/.aspnet/https:ro
 
   tfst-sqlserver:
     image: mcr.microsoft.com/mssql/server:2019-latest


### PR DESCRIPTION
README.md with solution for the problem: changes in `.env` are not reflected in the application.
changes in docker-compose for API runs on HTTPS by default.

delete SSL old certificate and apply this comand for generate a SSL new certificate (change NewPassword):
- dotnet dev-certs https -ep "%APPDATA%\ASP.NET\Https\TheFullStackTeam.API.pfx" -p "NewPassword"