### PR TITLE
feat: Define domain-purpose mapping and deployment strategy for TFST

### DIFF
--- a/src/clients/README.md
+++ b/src/clients/README.md
@@ -1,0 +1,68 @@
+# TFST Clients — Frontend Applications and Portals
+
+This folder contains all web clients and public-facing portals for the **TFST platform**, each mapped to a specific domain, purpose, and audience.
+
+## Overview
+
+| Folder             | Domain            | Purpose                                         | Deployment Target     |
+|--------------------|-------------------|--------------------------------------------------|------------------------|
+| `tfst-app`         | `tfst.app`        | Main SaaS application for registered users       | Azure App Service (dev, beta) |
+| `tfst-xyz`         | `tfst.xyz`        | Public-facing app for profiles and onboarding    | Azure App Service (dev, beta) |
+| `tfst-dev`         | `tfst.dev`        | Technical documentation and dev portal           | Azure Static Web App (prod only) |
+| `full-stack-team`  | `full-stack.team` | Institutional marketing site                     | Azure Static Web App (prod only) |
+
+---
+
+## Purpose by Domain
+
+- **`tfst.app`** – Authenticated app for users to manage projects, contracts, and profiles.
+- **`tfst.xyz`** – Public entry point into the TFST ecosystem. Explore talent, view profiles, and onboard.
+- **`tfst.dev`** – Open-source hub and documentation site for developers and contributors.
+- **`full-stack.team`** – Marketing, branding, and conversion funnel for companies and professionals.
+
+---
+
+## Environments
+
+| Environment | App Services                     | Static Web Apps               |
+|-------------|----------------------------------|-------------------------------|
+| `dev`       | `api`, `auth`, `tfst.app`, `tfst.xyz` (Azure defaults) | — |
+| `beta`      | Custom domains with SSL for all | — |
+| `portals`   | —                                | `tfst.dev`, `full-stack.team` |
+
+---
+
+## Repositories & Structure
+
+Each subfolder is either an Angular app (for app-like frontends) or a static site (Docusaurus, Astro, etc.). All are independently deployable and versioned:
+
+- `tfst-app/` – Angular SPA (SaaS UI)
+- `tfst-xyz/` – Angular SPA (public explorer)
+- `tfst-dev/` – Docusaurus or Astro site
+- `full-stack-team/` – Angular (static + i18n) or Jamstack site
+
+---
+
+## 🌐 Subdomain Naming Conventions
+
+The TFST platform follows these domain and subdomain rules across environments:
+
+### Application Services (App Service based)
+
+| Component         | Dev Domain                        | Beta (Prod) Domain     |
+|------------------|------------------------------------|------------------------|
+| Auth Server       | `tfst-auth-dev.azurewebsites.net`       | `auth.tfst.app`        |
+| API               | `tfst-api-dev.azurewebsites.net`        | `api.tfst.app`         |
+| SaaS Frontend     | `tfst-app-dev.azurewebsites.net`   | `tfst.app`             |
+| Public Frontend   | `tfst-xyz-dev.azurewebsites.net`   | `tfst.xyz`             |
+
+### Static Portals (Azure Static Web Apps)
+
+| Portal            | Dev Domain     | Production Domain    |
+|-------------------|----------------|-----------------------|
+| Documentation     | —              | `tfst.dev`            |
+| Marketing Site    | —              | `full-stack.team`     |
+
+- Development uses default Azure-generated domains (no custom SSL).
+- Beta acts as production and uses custom domains with SSL certificates.
+- Static sites are deployed only to production.

--- a/src/clients/tfst-xyz/README.md
+++ b/src/clients/tfst-xyz/README.md
@@ -1,0 +1,27 @@
+# TFST Public Platform (tfst.xyz)
+
+This is the **public-facing web application** of TFST, focused on exploring the ecosystem, discovering talent, and onboarding new users.
+
+## Purpose
+
+The **tfst.xyz** site acts as the **ecosystem gateway** to TFST. It allows unauthenticated users to explore professional profiles, learn about the platform, and initiate the onboarding process toward hiring or collaboration.
+
+## Key Features
+
+- **ESCO-Based Profile Discovery:** Search and view freelancer and team profiles by skill, occupation, or experience.
+- **Public Talent Explorer:** View endorsements, portfolios, and availability.
+- **Onboarding Flows:** Register as a freelancer, company, or external contractor.
+- **Open Opportunities:** Browse available projects and collaboration offers.
+
+## Target Audience
+
+- **Clients & Businesses** exploring the TFST talent pool.
+- **New Freelancers** seeking to onboard into the platform.
+- **Integrators & Observers** evaluating TFST before signing up.
+
+## Deployment
+
+This app is built with **Angular** and consumes the same **API and authentication infrastructure** as `tfst.app`. It is deployed in both **development and beta environments** under:
+
+- `dev`: Azure default domain
+- `beta`: `tfst.xyz` (custom domain with SSL)


### PR DESCRIPTION
This PR documents and aligns the purpose, audience, and deployment strategy for each official TFST domain, ensuring clarity across environments, apps, and portals.

- tfst.app – Main SaaS application for authenticated users 
- tfst.xyz – Public-facing platform for profile exploration and onboarding 
- tfst.dev – Developer portal for documentation and contribution
- full-stack.team – Institutional marketing site for TFST as a team

This completes task #101 and lays a clean foundation for future IaaC, CI/CD and multi-team collaboration.